### PR TITLE
Added recursive option of open and close api #25

### DIFF
--- a/src/js/tree.js
+++ b/src/js/tree.js
@@ -989,8 +989,8 @@ var Tree = snippet.defineClass(/** @lends Tree.prototype */ {
      * @private
      */
     _closeNode: function(nodeId) {
-        var node = this.model.getNode(nodeId),
-            state = nodeStates.CLOSED;
+        var node = this.model.getNode(nodeId);
+        var state = nodeStates.CLOSED;
         var isAllowStateChange = (
             node &&
             !node.isRoot() &&

--- a/src/js/tree.js
+++ b/src/js/tree.js
@@ -904,16 +904,49 @@ var Tree = snippet.defineClass(/** @lends Tree.prototype */ {
 
         return node.getState();
     },
-
     /**
      * Open node
      * @param {string} nodeId - Node id
+     * @param {object} [options] - Options
+     *     @param {boolean} [options.recursive] - If true, it open all parent
+     * @example
+     * tree.close(nodeId);
+     * // Add option
+     * tree.open(nodeId ,{
+     *    recursive: true
+     * });
      */
-    open: function(nodeId) {
+    open: function(nodeId, options) {
+        var recursive = options ? options.recursive : false;
+
+        if (recursive) {
+            this._openRecursiveNode(nodeId);
+        } else {
+            this._openNode(nodeId);
+        }
+    },
+    /**
+     * Open all parent node
+     * @param {string} nodeId - Node id
+     * @private
+     */
+    _openRecursiveNode: function(nodeId) {
+        var parentIdList = this.model.getParentIds(nodeId);
+        parentIdList.push(nodeId);
+        snippet.forEach(parentIdList, function(parentId) {
+            this._openNode(parentId);
+        }, this);
+    },
+    /**
+     * Open one target node
+     * @param {string} nodeId - Node id
+     * @private
+     */
+    _openNode: function(nodeId) {
         var node = this.model.getNode(nodeId),
             state = nodeStates.OPENED;
 
-        if (node && !node.isRoot()) {
+        if (node && node.getState() === nodeStates.CLOSED && !node.isRoot()) {
             node.setState(state);
             this._setDisplayFromNodeState(nodeId, state);
         }
@@ -926,12 +959,46 @@ var Tree = snippet.defineClass(/** @lends Tree.prototype */ {
     /**
      * Close node
      * @param {string} nodeId - Node id
+     * @param {object} [options] - Options
+     *     @param {boolean} [options.recursive] - If true, it close all child node
+     * @example
+     * tree.close(nodeId);
+     * // Add option
+     * tree.close(nodeId ,{
+     *    recursive: true
+     * });
      */
-    close: function(nodeId) {
+    close: function(nodeId, options) {
+        var recursive = options ? options.recursive : false;
+
+        if (recursive) {
+            this._closeRecursiveNode(nodeId);
+        } else {
+            this._closeNode(nodeId);
+        }
+    },
+    /**
+     * Close all child node
+     * @param {string} nodeId - Node id
+     * @private
+     */
+    _closeRecursiveNode: function(nodeId) {
+        var childInternalIdList = this.model.getChildInternalNodeIds(nodeId);
+        childInternalIdList.push(nodeId);
+        snippet.forEach(childInternalIdList, function(childId) {
+            this._closeNode(childId);
+        }, this);
+    },
+    /**
+     * Close one target node
+     * @param {string} nodeId - Node id
+     * @private
+     */
+    _closeNode: function(nodeId) {
         var node = this.model.getNode(nodeId),
             state = nodeStates.CLOSED;
 
-        if (node && !node.isRoot()) {
+        if (node && node.getState() === nodeStates.OPENED && !node.isRoot()) {
             node.setState(state);
             this._setDisplayFromNodeState(nodeId, state);
         }

--- a/src/js/treeModel.js
+++ b/src/js/treeModel.js
@@ -136,22 +136,6 @@ var TreeModel = snippet.defineClass(/** @lends TreeModel.prototype */{
     },
 
     /**
-     * Get recursive child internal node ids
-     * @param {string} nodeId - Node id
-     * @returns {?Array.<string>} Child ids
-     */
-    getChildInternalNodeIds: function(nodeId) {
-        var childInternalNodeIds = [];
-        this.each(function(searchNode, searchNodeId) {
-            if (!searchNode.isLeaf()) {
-                childInternalNodeIds.push(searchNodeId);
-            }
-        }, nodeId);
-
-        return childInternalNodeIds;
-    },
-
-    /**
      * Get the number of nodes
      * @returns {number} The number of nodes
      */
@@ -228,8 +212,7 @@ var TreeModel = snippet.defineClass(/** @lends TreeModel.prototype */{
         var parentNodeId = node.getParentId();
 
         while (parentNodeId) {
-            id = parentNodeId;
-            node = this.getNode(id);
+            node = this.getNode(parentNodeId);
             parentNodeId = node.getParentId();
             parentsNodeList.push(node);
         }

--- a/src/js/treeModel.js
+++ b/src/js/treeModel.js
@@ -136,6 +136,22 @@ var TreeModel = snippet.defineClass(/** @lends TreeModel.prototype */{
     },
 
     /**
+     * Get recursive child internal node ids
+     * @param {string} nodeId - Node id
+     * @returns {?Array.<string>} Child ids
+     */
+    getChildInternalNodeIds: function(nodeId) {
+        var childInternalNodeIds = [];
+        this.each(function(searchNode, searchNodeId) {
+            if (!searchNode.isLeaf()) {
+                childInternalNodeIds.push(searchNodeId);
+            }
+        }, nodeId);
+
+        return childInternalNodeIds;
+    },
+
+    /**
      * Get the number of nodes
      * @returns {number} The number of nodes
      */
@@ -201,7 +217,27 @@ var TreeModel = snippet.defineClass(/** @lends TreeModel.prototype */{
 
         return node.getParentId();
     },
+    /**
+     * Return parents ids of node
+     * @param {string} id - Node id
+     * @returns {Array.<string>} Parents node ids
+     */
+    getParentIds: function(id) {
+        var parentsNodeList = [];
+        var node = this.getNode(id);
+        var parentNodeId = node.getParentId();
 
+        while (parentNodeId) {
+            id = parentNodeId;
+            node = this.getNode(id);
+            parentNodeId = node.getParentId();
+            parentsNodeList.push(node);
+        }
+
+        return map(parentsNodeList, function(parentsNode) {
+            return parentsNode.getId();
+        });
+    },
     /**
      * Remove a node with children.
      * - The update event will be fired with parent node.

--- a/test/tree.spec.js
+++ b/test/tree.spec.js
@@ -132,6 +132,48 @@ describe('Tree', function() {
         expect(textNode.nodeValue).toEqual(tree.stateLabels.opened);
     });
 
+    describe('"open(), close() recursive action"', function() {
+        var oneDepthId;
+        var twoDepthId;
+        var lastDepthId;
+        var oneDepthNode;
+        var twoDepthNode;
+        var lastDepthNode;
+
+        beforeEach(function() {
+            oneDepthId = tree.model.rootNode.getChildIds()[0];
+            oneDepthNode = tree.model.getNode(oneDepthId);
+            twoDepthId = oneDepthNode.getChildIds()[4];
+            twoDepthNode = tree.model.getNode(twoDepthId);
+            lastDepthId = twoDepthNode.getChildIds()[0];
+            lastDepthNode = tree.model.getNode(lastDepthId);
+        });
+
+        it('"open()" use recursive option should change the state of all parent nodes to "open"', function() {
+            tree.open(lastDepthId, {
+                recursive: true
+            });
+
+            expect(oneDepthNode.getState()).toEqual('opened');
+            expect(twoDepthNode.getState()).toEqual('opened');
+            expect(lastDepthNode.getState()).toEqual('opened');
+        });
+
+        it('"close()" use recursive option should change the state of all children nodes to "close"', function() {
+            tree.open(tree.model.rootNode.getChildIds()[0]);
+            tree.open(oneDepthNode.getChildIds()[4]);
+            tree.open(twoDepthNode.getChildIds()[0]);
+
+            tree.close(tree.model.rootNode.getChildIds()[0], {
+                recursive: true
+            });
+
+            expect(oneDepthNode.getState()).toEqual('closed');
+            expect(twoDepthNode.getState()).toEqual('closed');
+            expect(lastDepthNode.getState()).toEqual('closed');
+        });
+    });
+
     it('should fire doubleClick event', function() {
         var handler = jasmine.createSpy('doubleClick handler'),
             eventMock = {

--- a/test/tree.spec.js
+++ b/test/tree.spec.js
@@ -132,7 +132,7 @@ describe('Tree', function() {
         expect(textNode.nodeValue).toEqual(tree.stateLabels.opened);
     });
 
-    describe('"open(), close() recursive action"', function() {
+    describe('"open(), close()" recursive action', function() {
         var oneDepthId;
         var twoDepthId;
         var lastDepthId;
@@ -150,13 +150,11 @@ describe('Tree', function() {
         });
 
         it('"open()" use recursive option should change the state of all parent nodes to "open"', function() {
-            tree.open(lastDepthId, {
-                recursive: true
-            });
+            tree.open(lastDepthId, true);
 
-            expect(oneDepthNode.getState()).toEqual('opened');
-            expect(twoDepthNode.getState()).toEqual('opened');
-            expect(lastDepthNode.getState()).toEqual('opened');
+            expect(oneDepthNode.getState()).toBe('opened');
+            expect(twoDepthNode.getState()).toBe('opened');
+            expect(lastDepthNode.getState()).toBe('opened');
         });
 
         it('"close()" use recursive option should change the state of all children nodes to "close"', function() {
@@ -164,13 +162,11 @@ describe('Tree', function() {
             tree.open(oneDepthNode.getChildIds()[4]);
             tree.open(twoDepthNode.getChildIds()[0]);
 
-            tree.close(tree.model.rootNode.getChildIds()[0], {
-                recursive: true
-            });
+            tree.close(tree.model.rootNode.getChildIds()[0], true);
 
-            expect(oneDepthNode.getState()).toEqual('closed');
-            expect(twoDepthNode.getState()).toEqual('closed');
-            expect(lastDepthNode.getState()).toEqual('closed');
+            expect(oneDepthNode.getState()).toBe('closed');
+            expect(twoDepthNode.getState()).toBe('closed');
+            expect(lastDepthNode.getState()).toBe('closed');
         });
     });
 

--- a/test/treeModel.spec.js
+++ b/test/treeModel.spec.js
@@ -197,16 +197,7 @@ describe('TreeModel', function() {
         var oneDepthId = treeModel.rootNode.getChildIds()[0];
         var twoDepthId = treeModel.getNode(oneDepthId).getChildIds()[4];
         var lastDepthId = treeModel.getNode(twoDepthId).getChildIds()[1];
+
         expect(treeModel.getParentIds(lastDepthId)).toEqual([twoDepthId, oneDepthId, rootNodeId]);
-    });
-
-    it('getChildInternalNodeIds should return an array of recursive child internal node ids of that node.', function() {
-        var targetNodeId = treeModel.rootNode.getChildIds()[0];
-        var twoDepthId1 = treeModel.getNode(targetNodeId).getChildIds()[4];
-        var twoDepthId2 = treeModel.getNode(targetNodeId).getChildIds()[8];
-        var twoDepthId3 = treeModel.getNode(twoDepthId1).getChildIds()[0];
-        var allInternalNodeIds = treeModel.getChildInternalNodeIds(targetNodeId).sort();
-
-        expect(allInternalNodeIds).toEqual([twoDepthId1, twoDepthId2, twoDepthId3].sort());
     });
 });

--- a/test/treeModel.spec.js
+++ b/test/treeModel.spec.js
@@ -191,4 +191,22 @@ describe('TreeModel', function() {
         expect(handler).toHaveBeenCalledWith(grandChildId, firstChildId, rootId, -1);
         expect(treeModel.getNode(grandChildId).getParentId()).toEqual(rootId);
     });
+
+    it('getParentIds should return an array of parent nodes of that node.', function() {
+        var rootNodeId = treeModel.rootNode.getId();
+        var oneDepthId = treeModel.rootNode.getChildIds()[0];
+        var twoDepthId = treeModel.getNode(oneDepthId).getChildIds()[4];
+        var lastDepthId = treeModel.getNode(twoDepthId).getChildIds()[1];
+        expect(treeModel.getParentIds(lastDepthId)).toEqual([twoDepthId, oneDepthId, rootNodeId]);
+    });
+
+    it('getChildInternalNodeIds should return an array of recursive child internal node ids of that node.', function() {
+        var targetNodeId = treeModel.rootNode.getChildIds()[0];
+        var twoDepthId1 = treeModel.getNode(targetNodeId).getChildIds()[4];
+        var twoDepthId2 = treeModel.getNode(targetNodeId).getChildIds()[8];
+        var twoDepthId3 = treeModel.getNode(twoDepthId1).getChildIds()[0];
+        var allInternalNodeIds = treeModel.getChildInternalNodeIds(targetNodeId).sort();
+
+        expect(allInternalNodeIds).toEqual([twoDepthId1, twoDepthId2, twoDepthId3].sort());
+    });
 });


### PR DESCRIPTION
## 데모
- http://10.78.9.21:8081/examples/example01-basic.html

## 작업내용
- open() api에서 recursive 옵션을 통해서 옵션이 있을경우 닫혀진 부모노드들을 찾아 전부 열어준다.
- close() api도 recursive 옵션을 통해 옵션이 있을경우 하위 노드의 오픈된 노드들을 찾아 전부 닫아준다.