### PR TITLE
feat: add option - checkbox cascade (fix #26)

### DIFF
--- a/src/js/features/checkbox.js
+++ b/src/js/features/checkbox.js
@@ -34,6 +34,7 @@ var filter = snippet.filter,
  * @param {Tree} tree - Tree
  * @param {Object} option - Option
  *  @param {string} option.checkboxClassName - Classname of checkbox element
+ *  @param {boolean} option.checkboxThreeState - Use of three state option (default: true)
  * @ignore
  */
 var Checkbox = snippet.defineClass(/** @lends Checkbox.prototype */{ /*eslint-disable*/
@@ -52,6 +53,7 @@ var Checkbox = snippet.defineClass(/** @lends Checkbox.prototype */{ /*eslint-di
 
         this.tree = tree;
         this.checkboxClassName = option.checkboxClassName;
+        this.checkboxThreeState = (option.checkboxThreeState === false) ? option.checkboxThreeState : true;
         this.checkedList = [];
         this.rootCheckbox = document.createElement('INPUT');
         this.rootCheckbox.type = 'checkbox';
@@ -282,7 +284,9 @@ var Checkbox = snippet.defineClass(/** @lends Checkbox.prototype */{ /*eslint-di
         this._setClassName(nodeId, state);
 
         if (!stopPropagation) {
-            this._propagateState(nodeId, state);
+            if (this.checkboxThreeState) {
+                this._propagateState(nodeId, state);
+            }
             tree.fire(eventName, {nodeId: nodeId});
         }
     },

--- a/src/js/features/checkbox.js
+++ b/src/js/features/checkbox.js
@@ -41,7 +41,7 @@ var filter = snippet.filter,
  * @param {Tree} tree - Tree
  * @param {Object} option - Option
  *  @param {string} option.checkboxClassName - Classname of checkbox element
- *  @param {string|boolean} option.checkboxCascade - 'up', 'down', 'both', false (default: 'both')
+ *  @param {string|boolean} [option.checkboxCascade='both'] - 'up', 'down', 'both', false
  * @ignore
  */
 var Checkbox = snippet.defineClass(/** @lends Checkbox.prototype */{ /*eslint-disable*/
@@ -60,7 +60,7 @@ var Checkbox = snippet.defineClass(/** @lends Checkbox.prototype */{ /*eslint-di
 
         this.tree = tree;
         this.checkboxClassName = option.checkboxClassName;
-        this.checkboxCascade = this._purifyCascadeOption(option.checkboxCascade);
+        this.checkboxCascade = this._initCascadeOption(option.checkboxCascade);
         this.checkedList = [];
         this.rootCheckbox = document.createElement('INPUT');
         this.rootCheckbox.type = 'checkbox';
@@ -84,8 +84,9 @@ var Checkbox = snippet.defineClass(/** @lends Checkbox.prototype */{ /*eslint-di
     /**
      * @param {string|boolean} - Cascade option
      * @returns {string|boolean} Cascade option
+     * @private
      */
-    _purifyCascadeOption: function(cascadeOption) {
+    _initCascadeOption: function(cascadeOption) {
         var cascadeOptions = [CASCADE_UP, CASCADE_DOWN, CASCADE_BOTH, CASCADE_NONE];
         if (inArray(cascadeOption, cascadeOptions) === -1) {
             cascadeOption = CASCADE_BOTH;

--- a/test/features/checkbox.spec.js
+++ b/test/features/checkbox.spec.js
@@ -193,4 +193,29 @@ describe('Tree', function() {
         expect(tree.isIndeterminate(rootChildIds[0])).toBe(true);
         expect(tree.isChecked(rootChildIds[1])).toBe(true);
     });
+
+    describe('disable - ThreeOption', function() {
+        beforeEach(function() {
+            tree.enableFeature('Checkbox', {
+                checkboxClassName: 'tui-tree-checkbox',
+                checkboxThreeState: false
+            });
+        });
+        it('should children remain unchecked even if parents are checked.', function() {
+            var firstChildId = tree.getChildIds(tree.getRootNodeId())[0];
+
+            tree.check(firstChildId);
+            tree.each(function(node, nodeId) {
+                expect(tree.isChecked(nodeId)).toBe(false);
+            }, firstChildId);
+        });
+        it('should be not indeterminate even if some children are checked', function() {
+            var baseNodeId = tree.getChildIds(tree.getRootNodeId())[0],
+                childIds = tree.getChildIds(baseNodeId);
+
+            tree.check(childIds[0]);
+            expect(tree.isIndeterminate(baseNodeId)).toBe(false);
+            expect(tree.isChecked(baseNodeId)).toBe(false);
+        });
+    });
 });

--- a/test/features/checkbox.spec.js
+++ b/test/features/checkbox.spec.js
@@ -194,28 +194,93 @@ describe('Tree', function() {
         expect(tree.isChecked(rootChildIds[1])).toBe(true);
     });
 
-    describe('disable - ThreeOption', function() {
+    describe('When cascade option is both', function() {
         beforeEach(function() {
             tree.enableFeature('Checkbox', {
                 checkboxClassName: 'tui-tree-checkbox',
-                checkboxThreeState: false
+                checkboxCascade: 'both'
             });
+            this.firstChildId = tree.getChildIds(tree.getRootNodeId())[0];
+            this.childIds = tree.getChildIds(this.firstChildId);
         });
-        it('should children remain unchecked even if parents are checked.', function() {
-            var firstChildId = tree.getChildIds(tree.getRootNodeId())[0];
+        it('should check with all descendants', function() {
+            tree.check(this.firstChildId);
+            tree.each(function(node, nodeId) {
+                expect(tree.isChecked(nodeId)).toBe(true);
+            }, this.firstChildId);
+        });
+        it('should be indeterminate if some children are checked', function() {
+            tree.check(this.childIds[0]);
+            expect(tree.isIndeterminate(this.firstChildId)).toBe(true);
+        });
+    });
 
-            tree.check(firstChildId);
+    describe('When cascade option is false', function() {
+        beforeEach(function() {
+            tree.enableFeature('Checkbox', {
+                checkboxClassName: 'tui-tree-checkbox',
+                checkboxCascade: false
+            });
+            this.firstChildId = tree.getChildIds(tree.getRootNodeId())[0];
+            this.childIds = tree.getChildIds(this.firstChildId);
+        });
+
+        it('should children remain unchecked even if parents are checked.', function() {
+            tree.check(this.firstChildId);
             tree.each(function(node, nodeId) {
                 expect(tree.isChecked(nodeId)).toBe(false);
-            }, firstChildId);
+            }, this.firstChildId);
         });
-        it('should be not indeterminate even if some children are checked', function() {
-            var baseNodeId = tree.getChildIds(tree.getRootNodeId())[0],
-                childIds = tree.getChildIds(baseNodeId);
 
-            tree.check(childIds[0]);
-            expect(tree.isIndeterminate(baseNodeId)).toBe(false);
-            expect(tree.isChecked(baseNodeId)).toBe(false);
+        it('should be not indeterminate even if some children are checked', function() {
+            tree.check(this.childIds[0]);
+            expect(tree.isIndeterminate(this.firstChildId)).toBe(false);
+        });
+    });
+
+    describe('When cascade option is up', function() {
+        beforeEach(function() {
+            tree.enableFeature('Checkbox', {
+                checkboxClassName: 'tui-tree-checkbox',
+                checkboxCascade: 'up'
+            });
+            this.firstChildId = tree.getChildIds(tree.getRootNodeId())[0];
+            this.childIds = tree.getChildIds(this.firstChildId);
+        });
+
+        it('should children remain unchecked even if parents are checked.', function() {
+            tree.check(this.firstChildId);
+            tree.each(function(node, nodeId) {
+                expect(tree.isChecked(nodeId)).toBe(false);
+            }, this.firstChildId);
+        });
+
+        it('should be indeterminate if some children are checked', function() {
+            tree.check(this.childIds[0]);
+            expect(tree.isIndeterminate(this.firstChildId)).toBe(true);
+        });
+    });
+
+    describe('When cascade option is down', function() {
+        beforeEach(function() {
+            tree.enableFeature('Checkbox', {
+                checkboxClassName: 'tui-tree-checkbox',
+                checkboxCascade: 'down'
+            });
+            this.firstChildId = tree.getChildIds(tree.getRootNodeId())[0];
+            this.childIds = tree.getChildIds(this.firstChildId);
+        });
+
+        it('should check with all descendants', function() {
+            tree.check(this.firstChildId);
+            tree.each(function(node, nodeId) {
+                expect(tree.isChecked(nodeId)).toBe(true);
+            }, this.firstChildId);
+        });
+
+        it('should be not indeterminate even if some children are checked', function() {
+            tree.check(this.childIds[0]);
+            expect(tree.isIndeterminate(this.firstChildId)).toBe(false);
         });
     });
 });


### PR DESCRIPTION
## 데모
- http://10.78.9.21:8081/examples/example07-cascade-false.html
- http://10.78.9.21:8081/examples/example07-cascade-both.html
- http://10.78.9.21:8081/examples/example07-cascade-up.html
- http://10.78.9.21:8081/examples/example07-cascade-down.html

## 작업내용
- cascade option ('up', 'down', 'both', false) 에 따라서 부모와, 자식 노드간에 관계설정이 바뀐다.
    1. both - up, down 상태 모드 체크하여 같이 변화함 (수정 전 기본상태)   
    2. false - 노드관에 관계가 완전히 끊김.
    3. up - 자식노드의 상태가 변하면 부모노드가 같이 변화함.
    4. down - 부모노드의 상태가 변하면 자식노드가 같이 변함.
