### PR TITLE
feat: add parameter about how to end edit mode

### DIFF
--- a/examples/example08-ajax.html
+++ b/examples/example08-ajax.html
@@ -151,7 +151,7 @@
 
         tree.on('beforeCreateChildNode', function(event) {
             if (event.cause === 'blur') {
-                tree.exitEdit();
+                tree.finishEditing();
                 tree.remove(event.nodeId);
                 return false;
             }
@@ -160,7 +160,7 @@
 
         tree.on('beforeEditNode', function(event) {
             if (event.cause === 'blur') {
-                tree.exitEdit();
+                tree.finishEditing();
                 return false;
             }
             return confirm('edit?');

--- a/examples/example08-ajax.html
+++ b/examples/example08-ajax.html
@@ -149,11 +149,20 @@
             }
         });
 
-        tree.on('beforeCreateChildNode', function() {
+        tree.on('beforeCreateChildNode', function(event) {
+            if (event.cause === 'blur') {
+                tree.exitEdit();
+                tree.remove(event.nodeId);
+                return false;
+            }
             return confirm('create?');
         });
 
-        tree.on('beforeEditNode', function() {
+        tree.on('beforeEditNode', function(event) {
+            if (event.cause === 'blur') {
+                tree.exitEdit();
+                return false;
+            }
             return confirm('edit?');
         });
 

--- a/src/js/features/ajax.js
+++ b/src/js/features/ajax.js
@@ -17,7 +17,7 @@ var LOADER_CLASSNAME = 'tui-tree-loader';
  *  @param {boolean} [options.isLoadRoot] - Whether load data from root node or not
  * @ignore
  */
-var Ajax = snippet.defineClass(/** @lends Ajax.prototype */{/*eslint-disable*/
+var Ajax = snippet.defineClass(/** @lends Ajax.prototype */{
     static: {
         /**
          * @static

--- a/src/js/features/checkbox.js
+++ b/src/js/features/checkbox.js
@@ -44,7 +44,7 @@ var filter = snippet.filter,
  *  @param {string|boolean} [option.checkboxCascade='both'] - 'up', 'down', 'both', false
  * @ignore
  */
-var Checkbox = snippet.defineClass(/** @lends Checkbox.prototype */{ /*eslint-disable*/
+var Checkbox = snippet.defineClass(/** @lends Checkbox.prototype */{
     static: {
         /**
          * @static
@@ -82,7 +82,7 @@ var Checkbox = snippet.defineClass(/** @lends Checkbox.prototype */{ /*eslint-di
     },
 
     /**
-     * @param {string|boolean} - Cascade option
+     * @param {string|boolean} cascadeOption - Cascade option
      * @returns {string|boolean} Cascade option
      * @private
      */
@@ -91,6 +91,7 @@ var Checkbox = snippet.defineClass(/** @lends Checkbox.prototype */{ /*eslint-di
         if (inArray(cascadeOption, cascadeOptions) === -1) {
             cascadeOption = CASCADE_BOTH;
         }
+
         return cascadeOption;
     },
 

--- a/src/js/features/contextMenu.js
+++ b/src/js/features/contextMenu.js
@@ -20,7 +20,7 @@ var bind = snippet.bind;
  *     @param {Array.<Object>} options.menuData - Context menu data
  * @ignore
  */
-var ContextMenu = snippet.defineClass(/** @lends ContextMenu.prototype */{/*eslint-disable*/
+var ContextMenu = snippet.defineClass(/** @lends ContextMenu.prototype */{
     static: {
         /**
          * @static

--- a/src/js/features/draggable.js
+++ b/src/js/features/draggable.js
@@ -472,7 +472,9 @@ var Draggable = snippet.defineClass(/** @lends Draggable.prototype */{
         if (!this.hoveredElement && isContain) {
             this.hoveredElement = currentElement;
             this._hover(nodeId);
-        } else if (!hasClass || (hasClass && !isContain)) {
+        } else if (!hasClass) {
+            this._unhover();
+        } else if (!isContain) {
             this._unhover();
         }
 

--- a/src/js/features/draggable.js
+++ b/src/js/features/draggable.js
@@ -52,7 +52,7 @@ var API_LIST = [];
  *     @param {{top: number, bottom: number}} options.lineBoundary - Boundary value for visible moving line
  * @ignore
  */
-var Draggable = snippet.defineClass(/** @lends Draggable.prototype */{/*eslint-disable*/
+var Draggable = snippet.defineClass(/** @lends Draggable.prototype */{
     static: {
         /**
          * @static

--- a/src/js/features/editable.js
+++ b/src/js/features/editable.js
@@ -9,7 +9,8 @@ var snippet = require('tui-code-snippet');
 
 var API_LIST = [
     'createChildNode',
-    'editNode'
+    'editNode',
+    'exitEdit'
 ];
 var EDIT_TYPE = {
     CREATE: 'create',
@@ -80,10 +81,10 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
         this.mode = null;
 
         /**
-         * Whether custom event is ignored or not
+         * For block blur when unintentional blur event occur when alert popup
          * @type {Boolean}
          */
-        this.isCustomEventIgnored = false;
+        this.blockBlur = false;
 
         /**
          * Keyup event handler
@@ -157,6 +158,19 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
     },
 
     /**
+     * Exit edit though remove input tag
+     * @memberof Tree.prototype
+     * @requires Editable
+     * @example
+     * tree.exitEdit();
+     */
+    exitEdit: function() {
+        if (this.inputElement) {
+            this._detachInputElement();
+        }
+    },
+
+    /**
      * Custom event handler "successResponse"
      * @param {string} type - Ajax command type
      * @param {Array.<string>} nodeIds - Added node ids on tree
@@ -189,13 +203,90 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
     },
 
     /**
+     * InputElement is keep going
+     * @private
+     */
+    _keepEdit: function() {
+        if (this.inputElement) {
+            this.inputElement.focus();
+        }
+    },
+
+    /**
+     * Reflect the value of inputElement to node for creating or editing
+     * @private
+     */
+    _submitInputResult: function(cause) {
+        var tree = this.tree;
+        var nodeId = tree.getNodeIdFromElement(this.inputElement);
+        var value = this.inputElement.value;
+        var event = {
+            value: value,
+            nodeId: nodeId,
+            cause: cause
+        };
+
+        if (this.mode === EDIT_TYPE.CREATE) {
+            /**
+             * @event Tree#beforeCreateChildNode
+             * @param {{value: string}} evt - Event data
+             *     @param {string} evt.value - Return value of creating input element
+             *     @param {string} evt.nodeId - Return id of creating node
+             *     @param {string} cause - Return 'blur' or 'enter' according cause of the event
+             * @example
+             * tree
+             *  .enableFeature('Editable')
+             *  .on('beforeCreateChildNode', function(evt) {
+             *      console.log(evt.value);
+             *      console.log(evt.nodeId);
+             *      console.log(evt.cause);
+             *      return false; // It cancels
+             *      // return true; // It execute next
+             *  });
+             */
+            if (!this.tree.invoke('beforeCreateChildNode', event)) {
+                this._keepEdit();
+                return false;
+            }
+            this._addData(nodeId, value);
+        } else {
+            /**
+             * @event Tree#beforeEditNode
+             * @param {{value: string}} evt - Event data
+             *     @param {string} evt.value - Return value of creating input element
+             *     @param {string} evt.nodeId - Return id of editing node
+             *     @param {string} evt.cause - Return 'blur' or 'enter' according cause of the event
+             * @example
+             * tree
+             *  .enableFeature('Editable')
+             *  .on('beforeEditNode', function(evt) {
+             *      console.log(evt.value);
+             *      console.log(evt.nodeId);
+             *      console.log(evt.cause);
+             *      return false; // It cancels
+             *      // return true; // It execute next
+             *  });
+             */
+            if (!this.tree.invoke('beforeEditNode', event)) {
+                this._keepEdit();
+                return false;
+            }
+            this._setData(nodeId, value);
+        }
+
+        this._detachInputElement();
+        return true;
+    },
+
+    /**
      * Event handler: keyup - input element
      * @param {Event} event - Key event
      * @private
      */
     _onKeyup: function(event) {
         if (util.getKeyCode(event) === 13) {
-            this.inputElement.blur();
+            this.blockBlur = true;
+            this._submitInputResult('enter');
         }
     },
 
@@ -204,16 +295,10 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
      * @private
      */
     _onBlur: function() {
-        if (this.isCustomEventIgnored || !this.inputElement) {
-            this.isCustomEventIgnored = false;
-
-            return;
-        }
-
-        if (this.mode === EDIT_TYPE.CREATE) {
-            this._addData();
+        if (this.blockBlur) {
+            this.blockBlur = false;
         } else {
-            this._setData();
+            this.blockBlur = !this._submitInputResult('blur');
         }
     },
 
@@ -268,6 +353,7 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
             this.inputElement = inputElement;
         }
 
+        this.blockBlur = false;
         this.inputElement.focus();
     },
 
@@ -278,17 +364,18 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
     _detachInputElement: function() {
         var tree = this.tree;
         var inputElement = this.inputElement;
+        var wrapperElement = this.inputElement.parentNode;
 
         util.removeEventListener(inputElement, 'keyup', this.boundOnKeyup);
         util.removeEventListener(inputElement, 'blur', this.boundOnBlur);
 
         util.removeElement(inputElement);
+        util.removeElement(wrapperElement)
 
         if (tree.enabledFeatures.Ajax) {
             tree.off(this, 'successAjaxResponse');
         }
 
-        this.isCustomEventIgnored = false;
         this.inputElement = null;
     },
 
@@ -296,76 +383,30 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
      * Add data of input element to node and detach input element on tree
      * @private
      */
-    _addData: function() {
+    _addData: function(nodeId, value) {
         var tree = this.tree;
-        var nodeId = tree.getNodeIdFromElement(this.inputElement);
         var parentId = tree.getParentId(nodeId);
-        var value = this.inputElement.value || this.defaultValue;
         var data = {};
 
-        /**
-         * @event Tree#beforeCreateChildNode
-         * @param {{value: string}} evt - Event data
-         *     @param {string} evt.value - Return value of creating input element
-         * @example
-         * tree
-         *  .enableFeature('Editable')
-         *  .on('beforeCreateChildNode', function(evt) {
-         *      console.log(evt.value);
-         *      return false; // It cancels
-         *      // return true; // It execute next
-         *  });
-         */
-        if (!this.tree.invoke('beforeCreateChildNode', {value: value})) {
-            this.isCustomEventIgnored = true;
-            this.inputElement.focus();
-
-            return;
-        }
-
         if (nodeId) {
-            data[this.dataKey] = value;
+            data[this.dataKey] = value? value : this.defaultValue;
             tree._remove(nodeId);
             tree.add(data, parentId);
         }
-        this._detachInputElement();
     },
 
     /**
      * Set data of input element to node and detach input element on tree
      * @private
      */
-    _setData: function() {
+    _setData: function(nodeId, value) {
         var tree = this.tree;
-        var nodeId = tree.getNodeIdFromElement(this.inputElement);
-        var value = this.inputElement.value;
         var data = {};
-
-        /**
-         * @event Tree#beforeEditNode
-         * @param {{value: string}} evt - Event data
-         *     @param {string} evt.value - Return value of editing input element
-         * @example
-         * tree
-         *  .enableFeature('Editable')
-         *  .on('beforeEditNode', function(evt) {
-         *      console.log(evt.value);
-         *      return false; // It cancels
-         *      // return true; // It execute next
-         *  });
-         */
-        if (!this.tree.invoke('beforeEditNode', {value: value})) {
-            this.isCustomEventIgnored = true;
-            this.inputElement.focus();
-
-            return;
-        }
 
         if (nodeId) {
             data[this.dataKey] = value;
             tree.setNodeData(nodeId, data);
         }
-        this._detachInputElement();
     },
 
     /**

--- a/src/js/features/editable.js
+++ b/src/js/features/editable.js
@@ -30,7 +30,7 @@ var INPUT_CLASSNAME = 'tui-tree-input';
  *  @param {string} [options.inputClassName] - Classname of input element
  * @ignore
  */
-var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-disable*/
+var Editable = snippet.defineClass(/** @lends Editable.prototype */{
     static: {
         /**
          * @static
@@ -214,7 +214,8 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
 
     /**
      * Invoke 'beforeCreateChildNode'
-     * @param {Event} event - Information of 'beforeCreateChildNode'
+     * @param {Object} event - Information of 'beforeCreateChildNode'
+     * @returns {boolean} Result of invoke event
      * @private
      */
     _invokeBeforeCreateChildNode: function(event) {
@@ -241,6 +242,7 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
     /**
      * Invoke 'beforeEditNode'
      * @param {Event} event - Information of 'beforeEditNode'
+     * @returns {boolean} Result of invoke event
      * @private
      */
     _invokeBeforeEditNode: function(event) {
@@ -266,6 +268,8 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
 
     /**
      * Reflect the value of inputElement to node for creating or editing
+     * @param {string} cause - how finish editing ('blur' or 'enter')
+     * @returns {boolean} Result of submit input result
      * @private
      */
     _submitInputResult: function(cause) {
@@ -389,7 +393,7 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
         util.removeEventListener(inputElement, 'keyup', this.boundOnKeyup);
         util.removeEventListener(inputElement, 'blur', this.boundOnBlur);
 
-        util.removeElement(wrapperElement)
+        util.removeElement(wrapperElement);
 
         if (tree.enabledFeatures.Ajax) {
             tree.off(this, 'successAjaxResponse');

--- a/src/js/features/editable.js
+++ b/src/js/features/editable.js
@@ -213,6 +213,58 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
     },
 
     /**
+     * Invoke 'beforeCreateChildNode'
+     * @param {Event} event - Information of 'beforeCreateChildNode'
+     * @private
+     */
+    _invokeBeforeCreateChildNode: function(event) {
+        /**
+         * @event Tree#beforeCreateChildNode
+         * @param {{value: string}} evt - Event data
+         *     @param {string} evt.value - Return value of creating input element
+         *     @param {string} evt.nodeId - Return id of creating node
+         *     @param {string} cause - Return 'blur' or 'enter' according cause of the event
+         * @example
+         * tree
+         *  .enableFeature('Editable')
+         *  .on('beforeCreateChildNode', function(evt) {
+         *      console.log(evt.value);
+         *      console.log(evt.nodeId);
+         *      console.log(evt.cause);
+         *      return false; // It cancels
+         *      // return true; // It execute next
+         *  });
+         */
+        return this.tree.invoke('beforeCreateChildNode', event);
+    },
+
+    /**
+     * Invoke 'beforeEditNode'
+     * @param {Event} event - Information of 'beforeEditNode'
+     * @private
+     */
+    _invokeBeforeEditNode: function(event) {
+        /**
+         * @event Tree#beforeEditNode
+         * @param {{value: string}} evt - Event data
+         *     @param {string} evt.value - Return value of creating input element
+         *     @param {string} evt.nodeId - Return id of editing node
+         *     @param {string} evt.cause - Return 'blur' or 'enter' according cause of the event
+         * @example
+         * tree
+         *  .enableFeature('Editable')
+         *  .on('beforeEditNode', function(evt) {
+         *      console.log(evt.value);
+         *      console.log(evt.nodeId);
+         *      console.log(evt.cause);
+         *      return false; // It cancels
+         *      // return true; // It execute next
+         *  });
+         */
+        return this.tree.invoke('beforeEditNode', event);
+    },
+
+    /**
      * Reflect the value of inputElement to node for creating or editing
      * @private
      */
@@ -227,48 +279,14 @@ var Editable = snippet.defineClass(/** @lends Editable.prototype */{/*eslint-dis
         };
 
         if (this.mode === EDIT_TYPE.CREATE) {
-            /**
-             * @event Tree#beforeCreateChildNode
-             * @param {{value: string}} evt - Event data
-             *     @param {string} evt.value - Return value of creating input element
-             *     @param {string} evt.nodeId - Return id of creating node
-             *     @param {string} cause - Return 'blur' or 'enter' according cause of the event
-             * @example
-             * tree
-             *  .enableFeature('Editable')
-             *  .on('beforeCreateChildNode', function(evt) {
-             *      console.log(evt.value);
-             *      console.log(evt.nodeId);
-             *      console.log(evt.cause);
-             *      return false; // It cancels
-             *      // return true; // It execute next
-             *  });
-             */
-            if (!this.tree.invoke('beforeCreateChildNode', event)) {
+            if (!this._invokeBeforeCreateChildNode(event)) {
                 this._keepEdit();
 
                 return false;
             }
             this._addData(nodeId, value);
         } else {
-            /**
-             * @event Tree#beforeEditNode
-             * @param {{value: string}} evt - Event data
-             *     @param {string} evt.value - Return value of creating input element
-             *     @param {string} evt.nodeId - Return id of editing node
-             *     @param {string} evt.cause - Return 'blur' or 'enter' according cause of the event
-             * @example
-             * tree
-             *  .enableFeature('Editable')
-             *  .on('beforeEditNode', function(evt) {
-             *      console.log(evt.value);
-             *      console.log(evt.nodeId);
-             *      console.log(evt.cause);
-             *      return false; // It cancels
-             *      // return true; // It execute next
-             *  });
-             */
-            if (!this.tree.invoke('beforeEditNode', event)) {
+            if (!this._invokeBeforeEditNode(event)) {
                 this._keepEdit();
 
                 return false;

--- a/src/js/features/selectable.js
+++ b/src/js/features/selectable.js
@@ -22,7 +22,7 @@ var API_LIST = [
  *  @param {string} options.selectedClassName - Classname for selected node.
  * @ignore
  */
-var Selectable = snippet.defineClass(/** @lends Selectable.prototype */{/*eslint-disable*/
+var Selectable = snippet.defineClass(/** @lends Selectable.prototype */{
     static: {
         /**
          * @static

--- a/src/js/treeNode.js
+++ b/src/js/treeNode.js
@@ -27,7 +27,7 @@ var lastIndex = 0,
  * @param {string} [parentId] - Parent node id
  * @ignore
  */
-var TreeNode = snippet.defineClass(/** @lends TreeNode.prototype */{ /*eslint-disable*/
+var TreeNode = snippet.defineClass(/** @lends TreeNode.prototype */{
     static: {
         /**
          * Set prefix of id

--- a/test/features/editable.spec.js
+++ b/test/features/editable.spec.js
@@ -119,4 +119,14 @@ describe('Tree', function() {
 
         expect(inputWrapper.style.paddingLeft).toBe(result + 'px');
     });
+
+    it('"finishEditing()" should remove input element of editing node', function() {
+        var inputElements;
+
+        tree.editNode(firstChildElement);
+        tree.finishEditing();
+        inputElements = firstChildElement.getElementsByTagName('input');
+
+        expect(inputElements.length).toBe(0);
+    });
 });

--- a/test/features/editable.spec.js
+++ b/test/features/editable.spec.js
@@ -123,10 +123,12 @@ describe('Tree', function() {
     it('"finishEditing()" should remove input element of editing node', function() {
         var inputElements;
 
-        tree.editNode(firstChildElement);
+        tree.editNode(firstChildId);
+        inputElements = firstChildElement.getElementsByTagName('input');
+        expect(inputElements.length).toBe(1);
+
         tree.finishEditing();
         inputElements = firstChildElement.getElementsByTagName('input');
-
         expect(inputElements.length).toBe(0);
     });
 });


### PR DESCRIPTION
# 요구사항
* Editable 완료 이벤트가 어떤 것인지 구분할 수 있는 기능 (엔터키, blur)
# 작업내용
*  "beforeCreateChildNode", "beforeEditNode" 이벤트 발생시에 어떻게 editable상황이 종료되었는지 매개변수 **cause**를 통해 알려주도록 함
* 기존에 사용중이던 isCustomEventIgnored 변수의 목적을 분명히 하기위해 blockblur로 변경함 (해당 변수가 들어간 원래 이유가 alert창의 버튼 클릭이 의도치 않은 blur 이벤트를 발생시키기 때문)
# 데모
http://10.78.8.175:8080/examples/example08-ajax.html

(데모는 blur키는 무시하고 엔터키로만 동작하도록 설정)